### PR TITLE
fix: update reset token expiry to current time upon successful reset

### DIFF
--- a/auth/internal/models/user.go
+++ b/auth/internal/models/user.go
@@ -112,6 +112,7 @@ func (u *User) ResetPassword(password string) error {
 	}
 
 	db.Model(&User{}).Where("id = ?", u.ID).Update("password", hashedPassword)
+	db.Model(&User{}).Where("id = ?", u.ID).Update("\"passwordResetExpiresAt\"", time.Now())
 
 	return nil
 }


### PR DESCRIPTION
change password reset token to expiry to current time of upon successful password update