### PR TITLE
fix: include /verify endpoint in the auth router

### DIFF
--- a/auth/internal/routes/router.go
+++ b/auth/internal/routes/router.go
@@ -16,6 +16,7 @@ func AppRouter() *mux.Router {
 	SignInRoute(router)
 	ForgotPasswordRoute(router)
 	ResetPasswordRoute(router)
+	verifyAuthRoute(router)
 
 	return router
 }


### PR DESCRIPTION
Include /verify endpoint in the auth app router